### PR TITLE
Mark as Substitute Package for Older `guzzle-description-loader`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9"
+    },
+    "replace": {
+        "gimler/guzzle-description-loader": "<=0.0.4",
+        "kezor/guzzle-description-loader": "<=0.0.4"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "141017e70c54d64defbd00b85bebe8e8",
+    "content-hash": "8b42c94a052bd1ea74e78a5dffd3a997",
     "packages": [
         {
             "name": "symfony/config",


### PR DESCRIPTION
This replaces all older forked versions of the package.